### PR TITLE
Parse tokens after a template defintion, as used in e.g. Boost

### DIFF
--- a/natvis4gdb.py
+++ b/natvis4gdb.py
@@ -241,6 +241,12 @@ class NvType(object):
                                     .format("<EOF>" if arg_start >= len(input) else input[arg_start]))
         arg_start += 1  # Consume the '>'
 
+        if arg_start < len(input):
+            # consume remaining items
+            arg_type, arg_end = NvType._template_type_parse_runner(input, arg_start)
+            args.append(arg_type)
+            arg_start = NvType._skip_whitespace(input, arg_end)
+
         return NvType(input[start:name_end], args), arg_start
 
     @staticmethod


### PR DESCRIPTION
Currently, the parsing stops after encountering the first template. However, e.g. Boost defines iterators on templates, see https://github.com/KindDragon/CPPDebuggerVisualizers/blob/master/VS2017/Visualizers/boost_Containers.natvis line 180. This change makes the parsing continue beyond the first template encounter.